### PR TITLE
タイトル画面の作成

### DIFF
--- a/Minge2023Spring_Team1/Minge2023Spring_Team1.vcxproj
+++ b/Minge2023Spring_Team1/Minge2023Spring_Team1.vcxproj
@@ -114,7 +114,9 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="common.cpp" />
-    <ClCompile Include="common.hpp" />
+    <ClCompile Include="common.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Stage.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/Minge2023Spring_Team1/Scene.hpp
+++ b/Minge2023Spring_Team1/Scene.hpp
@@ -2,6 +2,11 @@
 #include"common.hpp"
 class Title : public App::Scene
 {
+private:
+	int32 buttonNum = 2; // ボタンの数
+	int32 cursorPosition = 0; // ボタン選択位置
+	RectF button_startGame; // スタートボタン
+	RectF button_quit; // 終了ボタン
 public:
 
 	// コンストラクタ（必ず実装）

--- a/Minge2023Spring_Team1/Title.cpp
+++ b/Minge2023Spring_Team1/Title.cpp
@@ -4,18 +4,66 @@
 Title::Title(const InitData& init)
 	: IScene{ init }
 {
-
+	button_startGame = RectF{
+		Arg::center(Scene::Width() / 2, Scene::Height() * 0.6),
+		Vec2{ Scene::Width() * 0.2, Scene::Height() * 0.05 }
+	};
+	button_quit = RectF{
+		Arg::center(Scene::Width() / 2, Scene::Height() * 0.7),
+		Vec2{ Scene::Width() * 0.2, Scene::Height() * 0.05 }
+	};
 }
 
 // 更新関数
 void Title::update()
 {
+	// ボタン選択
+	if (inputUp.down() && cursorPosition != 0) {
+		cursorPosition--;
+		// cursorPosition = (cursorPosition + buttonNum) % buttonNum; // ボタン選択の上下ループ
+	}
+	if (inputDown.down() && cursorPosition != buttonNum - 1) {
+		cursorPosition++;
+		// cursorPosition %= buttonNum; // ボタン選択の上下ループ
+	}
 
+	// ボタン決定
+	if (KeyEnter.down()) {
+		//if (cursorPosition == 0) changeScene(SceneList::); // ステージセレクトへ遷移する
+		if (cursorPosition == 1) System::Exit(); // ゲーム終了
+	}
 }
 
 // 描画関数
 void Title::draw() const
 {
 	static const Font font(60);
-	font(U"This is Title").drawAt(Scene::Center());
+	static const Font font_button(30);
+
+	// タイトル名描画
+	font(U"This is Title").drawAt(Scene::Center() - Vec2{ 0, Scene::Height() * 0.2 });
+
+	// ボタン描画
+	if (cursorPosition == 0) {
+		// 選択されていた場合
+		button_startGame.draw(Palette::Gray);
+		button_startGame.drawFrame(3, Palette::Black);
+	}
+	else {
+		// されていない場合
+		button_startGame.draw();
+	}
+	font_button(U"ゲームスタート").drawAt(button_startGame.center(), Palette::Black);
+
+	if (cursorPosition == 1) {
+		// 選択されていた場合
+		button_quit.draw(Palette::Gray);
+		button_quit.drawFrame(3, Palette::Black);
+	}
+	else {
+		// されていない場合
+		button_quit.draw();
+	}
+	font_button(U"やめる").drawAt(button_quit.center(), Palette::Black);
+
 }

--- a/Minge2023Spring_Team1/Title.cpp
+++ b/Minge2023Spring_Team1/Title.cpp
@@ -27,10 +27,13 @@ void Title::update()
 		// cursorPosition %= buttonNum; // ボタン選択の上下ループ
 	}
 
+	if (button_startGame.mouseOver()) cursorPosition = 0;
+	else if (button_quit.mouseOver()) cursorPosition = 1;
+
 	// ボタン決定
-	if (KeyEnter.down()) {
-		//if (cursorPosition == 0) changeScene(SceneList::); // ステージセレクトへ遷移する
-		if (cursorPosition == 1) System::Exit(); // ゲーム終了
+	if (KeyEnter.down() || MouseL.down()) {
+		//if (cursorPosition == 0 || button_startGame.mouseOver()) changeScene(SceneList::); // ステージセレクトへ遷移する
+		if (cursorPosition == 1 || button_quit.mouseOver()) System::Exit(); // ゲーム終了
 	}
 }
 


### PR DESCRIPTION
# 概要
タイトル画面を作成しました。
上下キーでボタン選択、エンターキーで決定できます。
マウスでも選択できるようにしました。

**ステージセレクトへの遷移は未実装です。** Issue #8が完成次第対応するので、まだマージしないようにお願いします。

Close #5 