### PR TITLE
ターゲット破壊処理、クリア判定を実装

### DIFF
--- a/Minge2023Spring_Team1/App/tiles.csv
+++ b/Minge2023Spring_Team1/App/tiles.csv
@@ -1,4 +1,8 @@
-2,1,,Target
-0,Wall,None,T
-N,N,N,W
-N,N,W,N
+2,1,,Target,N,N,N,N
+0,Wall,None,T,N,N,N,N
+N,N,N,W,N,N,N,N
+N,N,W,N,N,N,N,N
+N,N,N,2,2,N,N,N
+N,N,N,2,N,N,N,N
+N,N,N,N,N,N,N,N
+N,N,N,N,N,N,N,N

--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -57,6 +57,7 @@ void Player::move(int direction, bool isDash) {
 			// ターゲットだった場合
 			// ターゲットを破壊してそのまま進む
 			tiles.breakTarget(nextPos);
+			if (tiles.getTargetNum() == 0) gameClearFlag = true;
 		}
 
 		// 移動確定
@@ -64,4 +65,8 @@ void Player::move(int direction, bool isDash) {
 
 		if (!isDash) break; // ダッシュが有効な場合、移動し続ける
 	}
+}
+
+bool Player::isGameCleared() const {
+	return gameClearFlag;
 }

--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -55,8 +55,8 @@ void Player::move(int direction, bool isDash) {
 		}
 		else if (tiles[nextPos.y][nextPos.x] == Tiles::Kind::Target) {
 			// ターゲットだった場合
-			// 移動せず終了
-			break;
+			// ターゲットを破壊してそのまま進む
+			tiles.breakTarget(nextPos);
 		}
 
 		// 移動確定

--- a/Minge2023Spring_Team1/Scene.hpp
+++ b/Minge2023Spring_Team1/Scene.hpp
@@ -28,6 +28,8 @@ public:
 	// 描画関数（オプション）
 	void draw() const override;
 private:
+	// ゲームクリアのときtrue
+	bool gameClearFlag = false;
 	Tiles tiles;
 	Player player;
 };

--- a/Minge2023Spring_Team1/Scene.hpp
+++ b/Minge2023Spring_Team1/Scene.hpp
@@ -28,8 +28,6 @@ public:
 	// 描画関数（オプション）
 	void draw() const override;
 private:
-	// ゲームクリアのときtrue
-	bool gameClearFlag = false;
 	Tiles tiles;
 	Player player;
 };

--- a/Minge2023Spring_Team1/Stage.cpp
+++ b/Minge2023Spring_Team1/Stage.cpp
@@ -39,8 +39,6 @@ Stage::Stage(const InitData& init)
 void Stage::update()
 {
 	player.update();
-	// ゲームクリア判定
-	if (tiles.getTargetNum() == 0) gameClearFlag = true;
 }
 
 // 描画関数   
@@ -53,7 +51,7 @@ void Stage::draw() const
 
 	player.draw(Scene::Center().x - tiles_size / 2, margin, Scene::Center().x + tiles_size / 2, Scene::Height() - margin);
 
-	if (gameClearFlag) {
+	if (player.isGameCleared()) {
 		// ゲームクリア時に表示
 		RectF gameClearBack{ 0, Scene::Height() * 0.35, Scene::Width(), Scene::Height() * 0.3 };
 		gameClearBack.draw(ColorF{ Palette::Gray, 0.8 });

--- a/Minge2023Spring_Team1/Stage.cpp
+++ b/Minge2023Spring_Team1/Stage.cpp
@@ -39,13 +39,24 @@ Stage::Stage(const InitData& init)
 void Stage::update()
 {
 	player.update();
+	// ゲームクリア判定
+	if (tiles.getTargetNum() == 0) gameClearFlag = true;
 }
 
-// 描画関数
+// 描画関数   
 void Stage::draw() const
 {
 	static int margin = 30, tiles_size = Scene::Height() - margin * 2;
+	static Font font_gameClear{ static_cast<int32>(Scene::Height() * 0.3 * 0.8), Typeface::Bold };
+
 	tiles.draw(Scene::Center().x - tiles_size / 2, margin, Scene::Center().x + tiles_size / 2, Scene::Height() - margin);
 
 	player.draw(Scene::Center().x - tiles_size / 2, margin, Scene::Center().x + tiles_size / 2, Scene::Height() - margin);
+
+	if (gameClearFlag) {
+		// ゲームクリア時に表示
+		RectF gameClearBack{ 0, Scene::Height() * 0.35, Scene::Width(), Scene::Height() * 0.3 };
+		gameClearBack.draw(ColorF{ Palette::Gray, 0.8 });
+		font_gameClear(U"GAME CLEAR!!").drawAt(gameClearBack.center(), Palette::Yellow);
+	}
 }

--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -20,6 +20,14 @@ public:
 	void draw(Point, Point) const;
 	void draw(int, int, int, int) const;
 
+	// @brief 残っているターゲットの数を返す
+	int32 getTargetNum() const;
+
+	// @brief 指定位置にあるターゲットを破壊する
+	// @param position 対象ターゲットの位置
+	// @return 正常に破壊できた場合trueを返す
+	bool breakTarget(Point position);
+
 private:
 	Array<Array<Kind>> tiles;
 };

--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -54,8 +54,12 @@ public:
 	* @param isDash ダッシュを有効にするか
 	*/
 	void move(int direction, bool isDash = false);
+	// @return ゲームクリア時true
+	bool isGameCleared() const;
 private:
-	// 盤上の位置
+	Tiles& tiles;
+	// 盤上での位置
 	Point position{ 0, 0 };
-	Tiles &tiles;
+	// ゲームクリア時にtrue
+	bool gameClearFlag = false;
 };

--- a/Minge2023Spring_Team1/tiles.cpp
+++ b/Minge2023Spring_Team1/tiles.cpp
@@ -64,3 +64,21 @@ void Tiles::draw(Point left_upper, Point right_bottom) const {
 void Tiles::draw(int x1, int y1, int x2, int y2) const {
 	draw(Point(x1, y1), Point(x2, y2));
 }
+
+int32 Tiles::getTargetNum() const {
+	int32 targetNum = 0;
+	for (int i = 0; i < tiles.size(); i++) {
+		for (int j = 0; j < tiles[i].size(); j++) {
+			if (tiles[i][j] == Tiles::Kind::Target) targetNum++;
+		}
+	}
+	return targetNum;
+}
+
+bool Tiles::breakTarget(Point position) {
+	if (tiles[position.y][position.x] == Tiles::Kind::Target) {
+		tiles[position.y][position.x] = Tiles::Kind::None;
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
# 変更内容
## `Player::move`メソッドを、ターゲットを破壊しながら進むように変更。
ダッシュ時は停止せず通り抜けながら破壊します
## `bool Player::isGameCleared() const`メソッドを追加
ゲームクリア時にtrueを返します
## `Tiles`クラスに以下のメソッドを追加
- `int32 getTargetNum() const`
盤上に残っているターゲットの数を返す
- `bool breakTarget(Point position)`
盤上の指定位置にあるターゲットを破壊する
## `Stage`シーンにゲームクリア判定と、クリア時の描画を簡易的に実装
現状では他のシーンへの遷移は実装していません

Close #19 