### PR TITLE
クリア後のスコア表示とステージセレクト画面への遷移の追加

### DIFF
--- a/Minge2023Spring_Team1/Main.cpp
+++ b/Minge2023Spring_Team1/Main.cpp
@@ -11,8 +11,6 @@ void Main()
 	manager.add<Stage>(SceneList::Stage);
 	manager.add<StageSelect>(SceneList::StageSelect);
 
-	manager.init(SceneList::StageSelect);
-
 	manager.init(SceneList::Stage);
 
 	// 画面サイズを変更

--- a/Minge2023Spring_Team1/Stage.cpp
+++ b/Minge2023Spring_Team1/Stage.cpp
@@ -69,7 +69,7 @@ void Stage::draw() const
 	player.draw(Scene::Center().x - tiles_size / 2, margin, Scene::Center().x + tiles_size / 2, Scene::Height() - margin);
 
 	const int score_x_pos = Scene::Center().x + tiles_size / 2 + 120;
-	font(clear_time.format(U"MM:ss:xx")).drawAt(score_x_pos, 50);
+	font(clear_time.format(U"MM:ss.xx")).drawAt(score_x_pos, 50);
 	font(U"歩行:{}回"_fmt(player.get_walk_count())).drawAt(score_x_pos, 100);
 
 	if (player.isGameCleared()) {
@@ -82,7 +82,7 @@ void Stage::draw() const
 		score_board.draw(Palette::White);
 
 		auto pos = font_gameClear(U"GAME CLEAR!!").draw(Arg::topCenter = score_board.topCenter(), Palette::Yellow);
-		pos = font_score(U"クリアタイム: {}"_fmt(clear_time.format(U"MM:ss:xx"))).draw(Arg::topCenter = pos.bottomCenter(), Palette::Black); // クリアタイムの表示
+		pos = font_score(U"クリアタイム: {}"_fmt(clear_time.format(U"MM:ss.xx"))).draw(Arg::topCenter = pos.bottomCenter(), Palette::Black); // クリアタイムの表示
 		pos = font_score(U"歩行回数: {}回"_fmt(player.get_walk_count())).draw(Arg::topCenter = pos.bottomCenter(), Palette::Black); // 歩行回数の表示
 		pos = font_score(U"スコア: {}"_fmt(U"hoge")).draw(Arg::topCenter = pos.bottomCenter(), Palette::Black); // スコアの表示
 		font_score(U"SHIFTキーでステージセレクトへ").draw(Arg::bottomCenter = score_board.bottomCenter(), Palette::Black);

--- a/Minge2023Spring_Team1/Stage.cpp
+++ b/Minge2023Spring_Team1/Stage.cpp
@@ -38,8 +38,6 @@ Stage::Stage(const InitData& init)
 // 更新関数
 void Stage::update()
 {
-	player.update();
-
 	// ゲームクリア時
 	if (player.isGameCleared()) {
 		// クリアタイムが動いていたら止める
@@ -51,7 +49,11 @@ void Stage::update()
 		if (KeyShift.down()) {
 			changeScene(SceneList::StageSelect);
 		}
+		return;
 	}
+
+	// ゲームプレイ時
+	player.update();
 }
 
 // 描画関数   


### PR DESCRIPTION
Close #24 

## 概要

ステージクリア後に以下の画像のようなスコア画面を追加しました。
詳細なスコアは算出方法が未確定のためいったんhogeにしています。

また、クリア後にステージセレクトシーンへの遷移ができるようにもしました。

![image](https://user-images.githubusercontent.com/71514776/224916089-905cd0ec-c982-4362-b99f-957d5e3514a6.png)
