### PR TITLE
プレイヤーの各行動のディレイ処理の実装

### DIFF
--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -72,16 +72,16 @@ void Player::draw(int x1, int y1, int x2, int y2) const {
 	draw(Point{ x1, y1 }, Point{ x2, y2 });
 }
 
-Player::Direction Player::move(Direction direction) {
+Player::Direction Player::move(Direction movingDirection) {
 	// 移動前位置を記録
 	lastPosition = position;
 
 	// 進行方向
 	Point deltaPos;
-	if (direction == Direction::Up) deltaPos = { 0, -1 };
-	else if (direction == Direction::Down) deltaPos = { 0, 1 };
-	else if (direction == Direction::Left) deltaPos = { -1, 0 };
-	else if (direction == Direction::Right) deltaPos = { 1, 0 };
+	if (movingDirection == Direction::Up) deltaPos = { 0, -1 };
+	else if (movingDirection == Direction::Down) deltaPos = { 0, 1 };
+	else if (movingDirection == Direction::Left) deltaPos = { -1, 0 };
+	else if (movingDirection == Direction::Right) deltaPos = { 1, 0 };
 	else return Direction::None;
 
 	Point nextPos = position + deltaPos;
@@ -106,7 +106,7 @@ Player::Direction Player::move(Direction direction) {
 	// 移動確定
 	position = nextPos;
 
-	return direction;
+	return movingDirection;
 }
 
 size_t Player::get_walk_count() const{

--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include"common.hpp"
+
 class Tiles {
 public:
 	// マスの種類
@@ -62,9 +63,14 @@ public:
 	bool isGameCleared() const;
 
 private:
+	Tiles& tiles;
+
 	// 盤上での位置
 	Point position{ 0, 0 };
-	Tiles &tiles;
+	// アニメーション開始時点での位置
+	Point lastPosition{ 0, 0 };
+	// 行動遅延タイマー（アニメーション用のタイマー）
+	Timer delayTimer{ 0s };
 
 	// 歩行回数
 	size_t walk_count=0;

--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -36,6 +36,14 @@ private:
 // プレイヤー
 class Player {
 public:
+	// 向き
+	enum class Direction {
+		Up,
+		Down,
+		Left,
+		Right,
+		None
+	};
 	/**
 	* @param tiles 盤面を参照するために必要
 	* @param position 初期位置
@@ -50,17 +58,20 @@ public:
 	// @brief 描画
 	void draw(int, int, int, int) const;
 	/**
-	* @brief 移動する
+	* @brief 移動する。次に移動すべき向きが戻り値で指定される。
 	* @param direction 移動方向（上:0 下:1 左:2 右:3）
-	* @param isDash ダッシュを有効にするか
+	* @return 次に移動する向き。壁があり移動できない場合はDirection::Noneが返される。
 	*/
-	void move(int direction, bool isDash = false);
+	Direction move(Direction direction);
 
 	// @brief 一マス移動の回数のゲッター関数
 	size_t get_walk_count() const;
 
 	// @return ゲームクリア時true
 	bool isGameCleared() const;
+
+	const Duration WALKING_DELAY = 0.4s; // 歩行遅延
+	const Duration DASHING_DELAY = 0.1s; // ダッシュ遅延
 
 private:
 	Tiles& tiles;
@@ -69,8 +80,12 @@ private:
 	Point position{ 0, 0 };
 	// アニメーション開始時点での位置
 	Point lastPosition{ 0, 0 };
+	// 向いている方向
+	Direction direction;
 	// 行動遅延タイマー（アニメーション用のタイマー）
-	Timer delayTimer{ 0s };
+	Timer delayTimer{ 0.1s };
+	// ダッシュ中true
+	bool dashFlag = false;
 
 	// 歩行回数
 	size_t walk_count=0;


### PR DESCRIPTION
# 概要
- ダッシュ処理を`Player::move`メソッドではなく、`Player::update`メソッド内で行うように変更しました。
- 行動遅延は仮で通常歩行0.4s、ダッシュ移動は距離依存で１マスあたり0.1sで設定しています。
# 詳細
## `Player::move`メソッドの仕様を変更
`Player::move`メソッドの引数でのダッシュフラグの指定を廃止し、１マスずつの移動のみ行うように仕様を変更しました。
そのため、ダッシュ移動の処理は`Player::update`メソッド内で行っています。

Close #36 