### PR TITLE
プレイヤーのテクスチャとアニメーションを導入

### DIFF
--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -38,10 +38,10 @@ class Player {
 public:
 	// 向き
 	enum class Direction {
-		Up,
-		Down,
-		Left,
-		Right,
+		Up = 0,
+		Down = 1,
+		Left = 2,
+		Right = 3,
 		None
 	};
 	/**
@@ -81,7 +81,9 @@ private:
 	// アニメーション開始時点での位置
 	Point lastPosition{ 0, 0 };
 	// 向いている方向
-	Direction direction;
+	Direction direction = Direction::Down;
+	// 描画上の向いている方向
+	Direction directionForDraw = Direction::Down;
 	// 行動遅延タイマー（アニメーション用のタイマー）
 	Timer delayTimer{ 0.1s };
 	// ダッシュ中true
@@ -92,4 +94,8 @@ private:
 
 	// ゲームクリア時にtrue
 	bool gameClearFlag = false;
+
+
+	// テクスチャ
+	Array<Texture> textures;
 };


### PR DESCRIPTION
- プレイヤーのテクスチャと歩行アニメーションを追加しました。
- Playerクラスに新たに`directionForDraw`メンバ変数を追加しました。
この変数は描画用の向きを保持する変数で、描画時に使用します。
将来的に、`Player::move`メソッドの戻り地によって進行方向の変更が行われた場合、描画上の進行方向と`direction`メンバ変数の向きが食い違ってしまうので追加しました。