### PR TITLE
反射壁を追加

### DIFF
--- a/Minge2023Spring_Team1/App/tiles.csv
+++ b/Minge2023Spring_Team1/App/tiles.csv
@@ -2,7 +2,7 @@
 0,Wall,None,T,N,N,N,N
 N,N,N,W,N,N,N,N
 N,N,W,N,N,N,N,N
-N,N,N,2,2,N,N,N
+N,RR,N,2,2,N,RL,N
 N,N,N,2,N,N,N,N
 N,N,N,N,N,N,N,N
 N,N,N,N,N,N,N,N

--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -19,7 +19,7 @@ void Player::update() {
 		// 移動処理が終わったら描画上の向きも更新
 		directionForDraw = direction;
 
-		if (!dashFlag) {
+		if (!dashFlag && !autoWalkFlag) {
 			// ダッシュ移動中でない場合
 			// 方向入力受付
 			if (inputUp.pressed()) direction = Direction::Up;
@@ -38,7 +38,9 @@ void Player::update() {
 			}
 			else {
 				// 通常歩行処理
-				if (move(direction) != Direction::None) {
+				MoveStatus moveStatus = move(direction);
+				if (moveStatus != MoveStatus::Failed) {
+					if (moveStatus == MoveStatus::AutoWalk) autoWalkFlag = true;
 					// 進行方向に壁がなく移動に成功した場合
 					walk_count++;
 					// 行動遅延設定
@@ -46,6 +48,8 @@ void Player::update() {
 					delayTimer.start();
 				}
 			}
+
+			return;
 			// ↑↑↑方向キーを押した場合の処理↑↑↑　ここまで
 		}
 
@@ -53,11 +57,10 @@ void Player::update() {
 			// ダッシュ移動中の場合
 
 			// そのまま移動する
-			Direction nextDirection = move(direction);
+			MoveStatus moveStatus = move(direction);
 
-			if (nextDirection != Direction::None) {
+			if (moveStatus != MoveStatus::Failed) {
 				// 移動できた場合
-				direction = nextDirection;
 				// 行動遅延設定
 				delayTimer.set(DASHING_DELAY);
 				delayTimer.start();
@@ -65,6 +68,27 @@ void Player::update() {
 			else {
 				// 移動できなかった場合、ダッシュ移動を終了する
 				dashFlag = false;
+			}
+		}
+		else if (autoWalkFlag) {
+			// 自動歩行中の場合
+
+			// そのまま移動する
+			MoveStatus moveStatus = move(direction);
+
+			autoWalkFlag = false;
+
+			if (moveStatus != MoveStatus::Failed) {
+				// 移動できた場合
+				// 自動歩行継続判定
+				if (moveStatus == MoveStatus::AutoWalk) autoWalkFlag = true;
+				// 行動遅延設定
+				delayTimer.set(WALKING_DELAY);
+				delayTimer.start();
+			}
+			else {
+				// 移動できなかった場合、自動歩行を終了する
+				autoWalkFlag = false;
 			}
 		}
 	}
@@ -95,7 +119,10 @@ void Player::draw(int x1, int y1, int x2, int y2) const {
 	draw(Point{ x1, y1 }, Point{ x2, y2 });
 }
 
-Player::Direction Player::move(Direction movingDirection) {
+Player::MoveStatus Player::move(Direction &movingDirection) {
+	// 戻り値
+	MoveStatus moveStatus = MoveStatus::None;
+
 	// 移動前位置を記録
 	lastPosition = position;
 
@@ -105,19 +132,19 @@ Player::Direction Player::move(Direction movingDirection) {
 	else if (movingDirection == Direction::Down) deltaPos = { 0, 1 };
 	else if (movingDirection == Direction::Left) deltaPos = { -1, 0 };
 	else if (movingDirection == Direction::Right) deltaPos = { 1, 0 };
-	else return Direction::None;
+	else return MoveStatus::Failed;
 
 	Point nextPos = position + deltaPos;
 
 	// 盤上範囲内チェック
-	if (nextPos.x < 0 || nextPos.y < 0 || nextPos.y >= tiles.size()) return Direction::None;
-	if (nextPos.x >= tiles[nextPos.y].size()) return Direction::None;
+	if (nextPos.x < 0 || nextPos.y < 0 || nextPos.y >= tiles.size()) return MoveStatus::Failed;
+	if (nextPos.x >= tiles[nextPos.y].size()) return MoveStatus::Failed;
 
 	// タイルチェック
 	if (tiles[nextPos.y][nextPos.x] == Tiles::Kind::Wall) {
 		// 壁だった場合
 		// 移動せず終了
-		return Direction::None;
+		return MoveStatus::Failed;
 	}
 	else if (tiles[nextPos.y][nextPos.x] == Tiles::Kind::Target) {
 		// ターゲットだった場合
@@ -129,7 +156,7 @@ Player::Direction Player::move(Direction movingDirection) {
 	// 移動確定
 	position = nextPos;
 
-	return movingDirection;
+	return moveStatus;
 }
 
 size_t Player::get_walk_count() const{

--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -154,18 +154,18 @@ Player::MoveStatus Player::move(Direction &movingDirection) {
 		// 斜め反射壁（＼）
 		moveStatus = MoveStatus::AutoWalk; // 自動歩行
 		// 移動方向変更
-		switch (direction) {
+		switch (movingDirection) {
 		case Direction::Up:
-			direction = Direction::Left;
+			movingDirection = Direction::Left;
 			break;
 		case Direction::Down:
-			direction = Direction::Right;
+			movingDirection = Direction::Right;
 			break;
 		case Direction::Left:
-			direction = Direction::Up;
+			movingDirection = Direction::Up;
 			break;
 		case Direction::Right:
-			direction = Direction::Down;
+			movingDirection = Direction::Down;
 			break;
 		}
 		break;
@@ -173,18 +173,18 @@ Player::MoveStatus Player::move(Direction &movingDirection) {
 		// 斜め反射壁（／）
 		moveStatus = MoveStatus::AutoWalk; // 自動歩行
 		// 移動方向変更
-		switch (direction) {
+		switch (movingDirection) {
 		case Direction::Up:
-			direction = Direction::Right;
+			movingDirection = Direction::Right;
 			break;
 		case Direction::Down:
-			direction = Direction::Left;
+			movingDirection = Direction::Left;
 			break;
 		case Direction::Left:
-			direction = Direction::Down;
+			movingDirection = Direction::Down;
 			break;
 		case Direction::Right:
-			direction = Direction::Up;
+			movingDirection = Direction::Up;
 			break;
 		}
 		break;

--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -141,16 +141,51 @@ Player::MoveStatus Player::move(Direction &movingDirection) {
 	if (nextPos.x >= tiles[nextPos.y].size()) return MoveStatus::Failed;
 
 	// タイルチェック
-	if (tiles[nextPos.y][nextPos.x] == Tiles::Kind::Wall) {
+	switch (tiles[nextPos.y][nextPos.x]) {
+	case Tiles::Kind::Wall:
 		// 壁だった場合
 		// 移動せず終了
 		return MoveStatus::Failed;
-	}
-	else if (tiles[nextPos.y][nextPos.x] == Tiles::Kind::Target) {
+	case Tiles::Kind::Target:
 		// ターゲットだった場合
 		// ターゲットを破壊して進む
 		tiles.breakTarget(nextPos);
 		if (tiles.getTargetNum() == 0) gameClearFlag = true;
+		break;
+	case Tiles::Kind::ReflectiveWallL:
+		moveStatus = MoveStatus::AutoWalk;
+		switch (direction) {
+		case Direction::Up:
+			direction = Direction::Left;
+			break;
+		case Direction::Down:
+			direction = Direction::Right;
+			break;
+		case Direction::Left:
+			direction = Direction::Up;
+			break;
+		case Direction::Right:
+			direction = Direction::Down;
+			break;
+		}
+		break;
+	case Tiles::Kind::ReflectiveWallR:
+		moveStatus = MoveStatus::AutoWalk;
+		switch (direction) {
+		case Direction::Up:
+			direction = Direction::Right;
+			break;
+		case Direction::Down:
+			direction = Direction::Left;
+			break;
+		case Direction::Left:
+			direction = Direction::Down;
+			break;
+		case Direction::Right:
+			direction = Direction::Up;
+			break;
+		}
+		break;
 	}
 
 	// 移動確定

--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -20,7 +20,7 @@ void Player::update() {
 		directionForDraw = direction;
 
 		if (!dashFlag && !autoWalkFlag) {
-			// ダッシュ移動中でない場合
+			// ダッシュ、自動歩行中でない場合
 			// 方向入力受付
 			if (inputUp.pressed()) direction = Direction::Up;
 			else if (inputDown.pressed()) direction = Direction::Down;
@@ -51,9 +51,7 @@ void Player::update() {
 
 			return;
 			// ↑↑↑方向キーを押した場合の処理↑↑↑　ここまで
-		}
-
-		if (dashFlag) {
+		} else if (dashFlag) {
 			// ダッシュ移動中の場合
 
 			// そのまま移動する
@@ -153,7 +151,9 @@ Player::MoveStatus Player::move(Direction &movingDirection) {
 		if (tiles.getTargetNum() == 0) gameClearFlag = true;
 		break;
 	case Tiles::Kind::ReflectiveWallL:
-		moveStatus = MoveStatus::AutoWalk;
+		// 斜め反射壁（＼）
+		moveStatus = MoveStatus::AutoWalk; // 自動歩行
+		// 移動方向変更
 		switch (direction) {
 		case Direction::Up:
 			direction = Direction::Left;
@@ -170,7 +170,9 @@ Player::MoveStatus Player::move(Direction &movingDirection) {
 		}
 		break;
 	case Tiles::Kind::ReflectiveWallR:
-		moveStatus = MoveStatus::AutoWalk;
+		// 斜め反射壁（／）
+		moveStatus = MoveStatus::AutoWalk; // 自動歩行
+		// 移動方向変更
 		switch (direction) {
 		case Direction::Up:
 			direction = Direction::Right;

--- a/Minge2023Spring_Team1/Stage.cpp
+++ b/Minge2023Spring_Team1/Stage.cpp
@@ -27,6 +27,12 @@ Stage::Stage(const InitData& init)
 			else if (v == U"2" or v == U"T" or v == U"Target") {
 				x << Tiles::Kind::Target;
 			}
+			else if (/*v == U"" or */ v == U"RL" or v == U"RefWallL") {
+				x << Tiles::Kind::ReflectiveWallL;
+			}
+			else if (/*v == U"" or */ v == U"RR" or v == U"RefWallR") {
+				x << Tiles::Kind::ReflectiveWallR;
+			}
 			else {
 				throw Error{ U"csvに変なモノ({})が混じっています"_fmt(v) };
 			}

--- a/Minge2023Spring_Team1/Stage.cpp
+++ b/Minge2023Spring_Team1/Stage.cpp
@@ -27,10 +27,10 @@ Stage::Stage(const InitData& init)
 			else if (v == U"2" or v == U"T" or v == U"Target") {
 				x << Tiles::Kind::Target;
 			}
-			else if (/*v == U"" or */ v == U"RL" or v == U"RefWallL") {
+			else if (v == U"5" or v == U"RL" or v == U"RefWallL") {
 				x << Tiles::Kind::ReflectiveWallL;
 			}
-			else if (/*v == U"" or */ v == U"RR" or v == U"RefWallR") {
+			else if (v == U"6" or v == U"RR" or v == U"RefWallR") {
 				x << Tiles::Kind::ReflectiveWallR;
 			}
 			else {

--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -69,6 +69,11 @@ public:
 		Right = 3,
 		None
 	};
+	enum class MoveStatus {
+		None, // 正常に終了
+		AutoWalk, // 自動的にもう一度移動する
+		Failed // 移動不可
+	};
 	/**
 	* @param tiles 盤面を参照するために必要
 	* @param position 初期位置
@@ -87,7 +92,7 @@ public:
 	* @param direction 移動方向（上:0 下:1 左:2 右:3）
 	* @return 次に移動する向き。壁があり移動できない場合はDirection::Noneが返される。
 	*/
-	Direction move(Direction direction);
+	MoveStatus move(Direction &direction);
 
 	// @brief 一マス移動の回数のゲッター関数
 	size_t get_walk_count() const;
@@ -113,6 +118,8 @@ private:
 	Timer delayTimer{ 0.1s };
 	// ダッシュ中true
 	bool dashFlag = false;
+	// 自動歩行中true
+	bool autoWalkFlag = false;
 
 	// 歩行回数
 	size_t walk_count=0;

--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -14,6 +14,8 @@ public:
 		None,
 		Wall,
 		Target,
+		ReflectiveWallL,
+		ReflectiveWallR,
 	};
 
 	Array<Kind>& operator[](size_t y);
@@ -89,8 +91,8 @@ public:
 	void draw(int, int, int, int) const;
 	/**
 	* @brief 移動する。次に移動すべき向きが戻り値で指定される。
-	* @param direction 移動方向（上:0 下:1 左:2 右:3）
-	* @return 次に移動する向き。壁があり移動できない場合はDirection::Noneが返される。
+	* @param[in,out] direction 移動方向（上:0 下:1 左:2 右:3）
+	* @return 処理結果 詳しくはMoveStatus参照
 	*/
 	MoveStatus move(Direction &direction);
 

--- a/Minge2023Spring_Team1/tiles.cpp
+++ b/Minge2023Spring_Team1/tiles.cpp
@@ -63,6 +63,14 @@ void Tiles::draw(Point left_upper, Point right_bottom) const {
 				drawNone(box, j, i);
 				Circle(box.pos + Vec2(block_size / 2, block_size / 2), block_size / 4).draw(Palette::White);
 				break;
+			case Tiles::Kind::ReflectiveWallL:
+				drawNone(box, j, i);
+				box.scaled(0.8, 0.15).rotated(45_deg).draw(Palette::Purple);
+				break;
+			case Tiles::Kind::ReflectiveWallR:
+				drawNone(box, j, i);
+				box.scaled(0.8, 0.15).rotated(-45_deg).draw(Palette::Purple);
+				break;
 			}
 
 			// マスのフレームを描画


### PR DESCRIPTION
# 変更内容
- **Player::moveメソッドの仕様を変更**
- 斜め反射壁を追加

## Player::moveメソッドの仕様を変更
`Direction Player::move(Direction movingDirection)` -> `MoveStatus Player::move(Direction  &movingDirection)`
次の進行方向を戻り値で指定する方法から、引数を参照渡しにして直接書き換える方法に変更。
また戻り値`Player::MoveStatus`で、壁があって進めなかった場合、反射壁などにより自動で歩行する場合などを指定できるように変更。

### `Player::MoveStatus`について
| 名前 | 意味 |
| ---- | ----- |
| None | 移動成功 |
| Failed | 移動不可 |
| AutoWalk | 斜め反射壁などにより、強制的にもう一度移動が入る場合 |

## 斜め反射壁を追加
名前
|| Tiles::Kind | csv |
| ---- | ---- | ---- |
| ＼ | ReflectiveWallL | RL, RefWallL |
| ／ | ReflectiveWallR | RR, RefWallR |

Close #27 