### PR TITLE
カウントダウンの実装

### DIFF
--- a/Minge2023Spring_Team1/EndlessStage.cpp
+++ b/Minge2023Spring_Team1/EndlessStage.cpp
@@ -44,19 +44,14 @@ EndlessStage::EndlessStage(const InitData& init)
 		}
 		tiles << x;
 	}
-	clear_time.restart();
+	timeLimit.restart();
 }
 
 // 更新関数
 void EndlessStage::update()
 {
-	// ゲームクリア時
-	if (player.isGameCleared()) {
-		// クリアタイムが動いていたら止める
-		if (clear_time.isRunning()) {
-			clear_time.pause();
-		}
-
+	// ゲームオーバー時
+	if (timeLimit.reachedZero()) {
 		// シフトを押したらシーンをステージセレクトに戻す
 		if (KeyShift.down()) {
 			changeScene(SceneList::StageSelect);
@@ -81,11 +76,11 @@ void EndlessStage::draw() const
 	player.draw(Scene::Center().x - tiles_size / 2, margin, Scene::Center().x + tiles_size / 2, Scene::Height() - margin);
 
 	const int score_x_pos = Scene::Center().x + tiles_size / 2 + 120;
-	font(clear_time.format(U"MM:ss.xx")).drawAt(score_x_pos, 50);
+	font(timeLimit.format(U"MM:ss.xx")).drawAt(score_x_pos, 50);
 	font(U"歩行:{}回"_fmt(player.get_walk_count())).drawAt(score_x_pos, 100);
 
-	if (player.isGameCleared()) {
-		// ゲームクリア時の表示
+	if (timeLimit.reachedZero()) {
+		// ゲームオーバー時の表示
 
 		RectF transparent{ 0, 0, Scene::Width(), Scene::Height() }; // ゲーム画面を透過するRectF
 		RectF score_board{ Arg::center(transparent.center()),Scene::Width() * 0.6, Scene::Height() * 0.6 };
@@ -93,8 +88,7 @@ void EndlessStage::draw() const
 		transparent.draw(ColorF{ Palette::Gray, 0.8 });
 		score_board.draw(Palette::White);
 
-		auto pos = font_gameClear(U"GAME CLEAR!!").draw(Arg::topCenter = score_board.topCenter(), Palette::Yellow);
-		pos = font_score(U"クリアタイム: {}"_fmt(clear_time.format(U"MM:ss.xx"))).draw(Arg::topCenter = pos.bottomCenter(), Palette::Black); // クリアタイムの表示
+		auto pos = font_gameClear(U"GAME OVER").draw(Arg::topCenter = score_board.topCenter(), Palette::Yellow);
 		pos = font_score(U"歩行回数: {}回"_fmt(player.get_walk_count())).draw(Arg::topCenter = pos.bottomCenter(), Palette::Black); // 歩行回数の表示
 		pos = font_score(U"スコア: {}"_fmt(U"hoge")).draw(Arg::topCenter = pos.bottomCenter(), Palette::Black); // スコアの表示
 		font_score(U"SHIFTキーでステージセレクトへ").draw(Arg::bottomCenter = score_board.bottomCenter(), Palette::Black);

--- a/Minge2023Spring_Team1/Scene.hpp
+++ b/Minge2023Spring_Team1/Scene.hpp
@@ -52,10 +52,16 @@ public:
 	// 描画関数（オプション）
 	void draw() const override;
 private:
+	// カウントダウン用のタイマー
 	Timer timeLimit{ 0.1min };
 
 	Tiles tiles;
 	Player player;
+
+	// ターゲット破壊時のタイマー基礎増加分
+	const Duration TIMER_INCREASE_BREAK_TARGET = 5s;
+	// 箱破壊時のタイマー基礎増加分
+	const Duration TIMER_INCREASE_BREAK_BOX = 5s;
 };
 
 class StageSelect : public App::Scene

--- a/Minge2023Spring_Team1/Scene.hpp
+++ b/Minge2023Spring_Team1/Scene.hpp
@@ -52,7 +52,7 @@ public:
 	// 描画関数（オプション）
 	void draw() const override;
 private:
-	Stopwatch clear_time;
+	Timer timeLimit{ 0.1min };
 
 	Tiles tiles;
 	Player player;

--- a/Minge2023Spring_Team1/StageClass.hpp
+++ b/Minge2023Spring_Team1/StageClass.hpp
@@ -10,6 +10,13 @@ enum class Direction {
 	None
 };
 
+// ゲーム上のイベント
+enum class GameEvent {
+	BreakTarget,
+	BreakBox,
+	None
+};
+
 class Tiles {
 public:
 	// @param stage_number ステージ番号
@@ -63,6 +70,10 @@ public:
 	// @param プレイヤーの位置と移動方向
 	void setAdjacentFlag(Point, Direction);
 
+	// @brief イベントのキューから一つ取り出す
+	// @return イベント種別　なにも無かった場合、GameEvent::None
+	GameEvent popEventQueue();
+
 private:
 	Array<Array<Kind>> tiles;
 
@@ -79,6 +90,9 @@ private:
 		Texture{U"sprites/grass_flower.png"},
 		Texture{U"sprites/grass_rock.png" },
 	};
+
+	// 箱、ターゲットの破壊などイベント情報を保持するキュー
+	Array<GameEvent> eventQueue;
 };
 
 // プレイヤー
@@ -95,7 +109,7 @@ public:
 	*/
 	Player(Tiles& tiles, Point position);
 
-	// 毎フレーム呼ぶ
+	// @brief 毎フレーム呼ぶ
 	void update();
 
 	// @brief 描画

--- a/Minge2023Spring_Team1/tiles.cpp
+++ b/Minge2023Spring_Team1/tiles.cpp
@@ -125,6 +125,8 @@ int32 Tiles::getTargetNum() const {
 bool Tiles::breakTarget(Point position) {
 	if (tiles[position.y][position.x] == Tiles::Kind::Target) {
 		tiles[position.y][position.x] = Tiles::Kind::None;
+		// ターゲットの破壊に成功
+		eventQueue << GameEvent::BreakTarget;
 		return true;
 	}
 	return false;
@@ -165,7 +167,12 @@ bool Tiles::moveBox(int x, int y, Direction direction) {
 	// 箱の新しい位置が壁か別の箱ならば、箱を消す
 	if (0 > new_pos.x or new_pos.x >= width_size() or new_pos.y < 0 or new_pos.y >= size() or (tiles[new_pos.y][new_pos.x] != Kind::Target and tiles[new_pos.y][new_pos.x] != Kind::None)) {
 		adjacent_flag = false;
+		eventQueue << GameEvent::BreakBox;
 		return true;
+	}
+	else if (tiles[new_pos.y][new_pos.x] == Kind::Target) {
+		// 箱の移動先にターゲットがあったら破壊する
+		breakTarget(new_pos);
 	}
 
 	// 新しい位置に箱を生やす
@@ -197,5 +204,14 @@ void Tiles::setAdjacentFlag(Point pos, Direction direction) {
 	}
 	else {
 		adjacent_flag = false;
+	}
+}
+
+GameEvent Tiles::popEventQueue() {
+	if (eventQueue.isEmpty()) return GameEvent::None;
+	else {
+		GameEvent gameEvent = eventQueue.front();
+		eventQueue.pop_front();
+		return gameEvent;
 	}
 }


### PR DESCRIPTION
# 変更内容
- エンドレスモードのカウントダウンタイマーの実装
- Tilesクラスにターゲット、箱の破壊などのイベント情報を保持するキュー`Array<GameEvent> Tiles::eventQueue`を追加
- `enum class GameEvent`を追加
## `Tiles::eventQueue`について
ゲーム上のイベント情報を保持します。
`Tiles::popEventQueue()`メソッドでキューの先頭から取り出すことができます。
キューにイベントを追加するときは、`eventQueue << GameEvent::Hoge`とします。
現状、EndlessStageクラス内で、カウントダウンタイマーの加算処理をするのに使用しています。
## `enum class GameEvent`について
ゲーム上のイベントの種類です。
現在実装してあるのは以下のとおりです。
| 名 | 意味 |
| ---- | ---- |
| BreakTarget | ターゲットが破壊された |
| BreakBox | 箱が破壊された |
| None | `popEventQueue()`を呼び出した際に、キューが空だったらこれが返される |

Close #30 