### PR TITLE
テクスチャ拡大各省時のフィルタを最近傍補間に変更した

### DIFF
--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -95,6 +95,9 @@ void Player::update() {
 }
 
 void Player::draw(Point left_upper, Point right_bottom) const {
+	// ドット絵をクリアに表示させる
+	const ScopedRenderStates2D sampler{ SamplerState::ClampNearest };
+
 	//ブロックのサイズ算出 (tiles.cppから引用)
 	double block_size = Min((double)(right_bottom.y - left_upper.y) / tiles.size(), (double)(right_bottom.x - left_upper.x) / tiles.width_size());
 

--- a/Minge2023Spring_Team1/tiles.cpp
+++ b/Minge2023Spring_Team1/tiles.cpp
@@ -41,6 +41,8 @@ Array<Array<Tiles::Kind>>::iterator Tiles::end() {
 
 // ブロックの描画
 void Tiles::draw(Point left_upper, Point right_bottom) const {
+	// ドット絵をクリアに表示させる
+	const ScopedRenderStates2D sampler{ SamplerState::ClampNearest };
 
 	//ブロックのサイズ算出
 	double block_size = Min((double)(right_bottom.y - left_upper.y) / size(), (double)(right_bottom.x - left_upper.x) / width_size());


### PR DESCRIPTION
Close #52 

下のURLを見て、draw部分に追加しただけです
https://zenn.dev/reputeless/books/siv3d-documentation/viewer/tutorial-renderstates2d#21.4-%E3%83%86%E3%82%AF%E3%82%B9%E3%83%81%E3%83%A3%E6%8B%A1%E5%A4%A7%E7%B8%AE%E5%B0%8F%E6%99%82%E3%81%AE%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%82%92%E5%A4%89%E3%81%88%E3%82%8B