### PR TITLE
タイトルシーンに背景画像を追加し、選択を見やすくした

### DIFF
--- a/Minge2023Spring_Team1/Scene.hpp
+++ b/Minge2023Spring_Team1/Scene.hpp
@@ -8,6 +8,8 @@ private:
 	int32 cursorPosition = 0; // ボタン選択位置
 	RectF button_startGame; // スタートボタン
 	RectF button_quit; // 終了ボタン
+
+	const Texture background{ U"sprites/title.png" }; // 背景の画像
 public:
 
 	// コンストラクタ（必ず実装）

--- a/Minge2023Spring_Team1/Title.cpp
+++ b/Minge2023Spring_Team1/Title.cpp
@@ -6,11 +6,11 @@ Title::Title(const InitData& init)
 {
 	button_startGame = RectF{
 		Arg::center(Scene::Width() / 2, Scene::Height() * 0.6),
-		Vec2{ Scene::Width() * 0.2, Scene::Height() * 0.05 }
+		Vec2{ Scene::Width() * 0.4, Scene::Height() * 0.1 }
 	};
 	button_quit = RectF{
-		Arg::center(Scene::Width() / 2, Scene::Height() * 0.7),
-		Vec2{ Scene::Width() * 0.2, Scene::Height() * 0.05 }
+		Arg::center(Scene::Width() / 2, Scene::Height() * 0.8),
+		Vec2{ Scene::Width() * 0.4, Scene::Height() * 0.1 }
 	};
 }
 
@@ -38,32 +38,38 @@ void Title::update()
 // 描画関数
 void Title::draw() const
 {
+	// ドット絵をクリアに表示させる
+	const ScopedRenderStates2D sampler{ SamplerState::ClampNearest };
+
 	static const Font font(60);
 	static const Font font_button(30);
 
+	// 背景画像の描画
+	background.resized(Scene::Width(), Scene::Height()).draw();
+
 	// タイトル名描画
-	font(U"This is Title").drawAt(Scene::Center() - Vec2{ 0, Scene::Height() * 0.2 });
+	font(U"ゲームタイトル！").drawAt(Scene::Center() - Vec2{ 0, Scene::Height() * 0.2 });
 
 	// ボタン描画
 	if (cursorPosition == 0) {
 		// 選択されていた場合
-		button_startGame.draw(Palette::Gray);
-		button_startGame.drawFrame(3, Palette::Black);
+		button_startGame.draw(Palette::White);
+		button_startGame.drawFrame(3,3, Palette::Deepskyblue);
 	}
 	else {
 		// されていない場合
-		button_startGame.draw();
+		button_startGame.draw(Palette::Gray);
 	}
 	font_button(U"ゲームスタート").drawAt(button_startGame.center(), Palette::Black);
 
 	if (cursorPosition == 1) {
 		// 選択されていた場合
-		button_quit.draw(Palette::Gray);
-		button_quit.drawFrame(3, Palette::Black);
+		button_quit.draw(Palette::White);
+		button_quit.drawFrame(3,3, Palette::Deepskyblue);
 	}
 	else {
 		// されていない場合
-		button_quit.draw();
+		button_quit.draw(Palette::Gray);
 	}
 	font_button(U"やめる").drawAt(button_quit.center(), Palette::Black);
 


### PR DESCRIPTION
Close #66 
タイトルの改善をしました。
- ゲーム選択をわかりやすくした
- 背景画像を追加した

![image](https://user-images.githubusercontent.com/71514776/235190051-45f079ad-f303-4454-9a2a-72f8a967e5f4.png)
