### PR TITLE
ゲームクリア判定がうまくされない不具合の修正

### DIFF
--- a/Minge2023Spring_Team1/Player.cpp
+++ b/Minge2023Spring_Team1/Player.cpp
@@ -165,7 +165,6 @@ Player::MoveStatus Player::move(Direction &movingDirection) {
 		// ターゲットだった場合
 		// ターゲットを破壊して進む
 		tiles.breakTarget(nextPos);
-		if (tiles.getTargetNum() == 0) gameClearFlag = true;
 		break;
 	case Tiles::Kind::Box:
 		if (not tiles.moveBox(nextPos.x, nextPos.y, movingDirection)) {
@@ -229,6 +228,8 @@ Player::MoveStatus Player::move(Direction &movingDirection) {
 		position = nextPos;
 		warpIsEnabled = true;
 	}
+
+	if (tiles.getTargetNum() == 0) gameClearFlag = true;
 
 	return moveStatus;
 }


### PR DESCRIPTION
箱、岩などを押してターゲットを破壊した場合にゲームクリア判定にならない問題を、プレイヤーが移動するたびにゲームクリア判定をすることで解決。